### PR TITLE
Fix for iOS (Wrong value for getBoundingClientRect.top)

### DIFF
--- a/view/frontend/web/js/sticky.js
+++ b/view/frontend/web/js/sticky.js
@@ -15,8 +15,15 @@ define([
      */
     function watch() {
         _.each(stickes, function (el) {
+            var boundingClientRectTop = Number(el.getBoundingClientRect().top);
+
+            // iOS fix
+            if (Math.abs(boundingClientRectTop) <= 1) {
+                boundingClientRectTop = 0;
+            }
+
             var top = parseInt($(el).css('top'), 10) || 0,
-                atTop = Number(el.getBoundingClientRect().top) === top,
+                atTop = boundingClientRectTop === top,
                 isStuck = $(el).hasClass(options.activeClassName);
 
             if (atTop && !isStuck) {

--- a/view/frontend/web/js/sticky.js
+++ b/view/frontend/web/js/sticky.js
@@ -8,7 +8,8 @@ define([
     var stickes = [],
         options = {
             activeClassName: 'sticky-active'
-        };
+        },
+        isIos = !!navigator.platform && /iPad|iPhone|iPod/.test(navigator.platform);
 
     /**
      * Watch for all stickes and add sticky-active class when needed
@@ -18,7 +19,7 @@ define([
             var boundingClientRectTop = Number(el.getBoundingClientRect().top);
 
             // iOS fix
-            if (Math.abs(boundingClientRectTop) <= 1) {
+            if (isIos && Math.abs(boundingClientRectTop) <= 1) {
                 boundingClientRectTop = 0;
             }
 

--- a/view/frontend/web/js/sticky.js
+++ b/view/frontend/web/js/sticky.js
@@ -16,16 +16,16 @@ define([
      */
     function watch() {
         _.each(stickes, function (el) {
-            var boundingClientRectTop = Number(el.getBoundingClientRect().top);
-
-            // iOS fix
-            if (isIos && Math.abs(boundingClientRectTop) <= 1) {
-                boundingClientRectTop = 0;
-            }
-
             var top = parseInt($(el).css('top'), 10) || 0,
+                boundingClientRectTop = Number(el.getBoundingClientRect().top),
                 atTop = boundingClientRectTop === top,
                 isStuck = $(el).hasClass(options.activeClassName);
+
+            // iOS fix.
+            // @see https://openradar.appspot.com/radar?id=6668472289329152
+            if (isIos && !atTop) {
+                atTop = boundingClientRectTop - top <= 1;
+            }
 
             if (atTop && !isStuck) {
                 $(el).addClass(options.activeClassName);


### PR DESCRIPTION
There is an issue on iOS with `getBoundingClientRect` for elements with sticky position on scroll:
https://openradar.appspot.com/radar?id=6668472289329152

`getBoundingClientRect.top` return random values less then 1 (can be positive or negative), but it should be zero.
This leads to missing `sticky-active` css class on an element.